### PR TITLE
Optimize imports by importing used PHP internal functions and constant.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,7 +8,17 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
+use function array_keys;
 use function file_exists;
+use function file_put_contents;
+use function in_array;
+use function is_file;
+use function md5;
+use function md5_file;
+use function sprintf;
+use function strpos;
+use function var_export;
+use const __DIR__;
 
 final class Plugin implements PluginInterface, EventSubscriberInterface
 {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,7 +18,6 @@ use function md5_file;
 use function sprintf;
 use function strpos;
 use function var_export;
-use const __DIR__;
 
 final class Plugin implements PluginInterface, EventSubscriberInterface
 {


### PR DESCRIPTION
When looking at this file, I found that only `file_exists` was imported while other PHP internal functions and constant were used.
This PR purpose is to add the missing ones.