### PR TITLE
Add PSR-12 Style on CodeSniffer ruleset. Exclude or customize conflict rules with PSR-12.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="PHPStan Extension Installer">
+
+	<!-- Code MUST follow all rules outlined in PSR-12. -->
+	<rule ref="PSR12"/>
+
 	<rule ref="vendor/consistence/coding-standard/Consistence/ruleset.xml">
 		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
@@ -9,6 +13,18 @@
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch"/>
 		<exclude name="Squiz.PHP.Heredoc.NotAllowed"/>
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed"/>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.MemberVarSpacing">
+		<properties>
+			<property name="spacingBeforeFirst" value="0"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
+		<properties>
+			<property name="linesCountAfterOpeningBrace" value="0"/>
+			<property name="linesCountBeforeClosingBrace" value="0"/>
+		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
 		<properties>


### PR DESCRIPTION
This is what I had in mind with #8 

The most important work is about the identation: the PSR-12 requires to have 4 spaces instead of tabs. If this is a rule you don't want because you prefer tabs, I can change the PR to exclude that rule and let the tabs. After all, what matters is consistency, not "tabs" or "spaces" endless war...

The other stuff is about the spaces before and after the braces on the class definition. Accoring to PSR-2: "Opening braces for classes MUST go on the next line, and closing braces MUST go on the next line after the body", that's why I reviewed some rules properties. It's better than excluding the rule.

Everything else is fine and follows the PSR-12.

I didn't know about the SlevomatCodingStandard, and they provide very good stuff! I might find a way to use some of their rules for my projects :smile:.

Anyway, if you don't want to accept all new changes but only a few, I can review the PR according to your coding rules.