### PR TITLE
Don't force the package type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ And that's it.
 
 ## Instructions for extension developers
 
-Extension's composer package [type](https://getcomposer.org/doc/04-schema.md#type) has to be set to `phpstan-extension` for this plugin to be able to recognize it.
-
 Only one feature is supported right now: PHPStan is able to automatically include the extension's config files, without you having to mention them in your `phpstan.neon`'s `includes` section.
 
 For this, you have to add a `phpstan` key in the extension `composer.json`'s `extra` section like so:
@@ -67,6 +65,9 @@ For this, you have to add a `phpstan` key in the extension `composer.json`'s `ex
   }
 }
 ```
+
+If you do not want to provide a `extra.phpstan.includes` configuration, then your extension's composer package [type](https://getcomposer.org/doc/04-schema.md#type) has to be set to `phpstan-extension` for this plugin to be able to recognize it.
+
 
 ## Limitations
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -82,7 +82,9 @@ PHP;
 
 		$data = [];
 		foreach ($composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
-			if ($package->getType() !== 'phpstan-extension') {
+			if ($package->getType() !== 'phpstan-extension'
+				&& !isset($package->getExtra()['phpstan']['includes'])
+			) {
 				if (
 					strpos($package->getName(), 'phpstan') !== false
 					&& !in_array($package->getName(), [


### PR DESCRIPTION
phpstan/extension-installer will work if the package type is `phpstan-extension` or if the `extra.phpstan.includes` key is configured.

Fixes #13 