### PR TITLE
Enhancement: Run ergebnis/composer-normalize in check target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,7 @@
 		composer,
 		lint,
 		cs,
+		composer-normalize-check,
 		phpstan
 	"/>
 
@@ -16,6 +17,31 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-check">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
+			<arg value="--dry-run"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-fix">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "name": "phpstan/extension-installer",
+    "type": "composer-plugin",
     "description": "Composer plugin for automatic installation of PHPStan extensions",
     "license": [
         "MIT"
     ],
-    "type": "composer-plugin",
     "require": {
         "php": "^7.1",
         "composer-plugin-api": "^1.1",
@@ -14,18 +14,18 @@
         "composer/composer": "^1.8",
         "consistence/coding-standard": "^3.8",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "ergebnis/composer-normalize": "^2.0.2",
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "phpstan/phpstan-strict-rules": "^0.11",
-        "slevomat/coding-standard": "^5.0.4",
         "phing/phing": "^2.16",
-        "ergebnis/composer-normalize": "^2.0.2"
+        "phpstan/phpstan-strict-rules": "^0.11",
+        "slevomat/coding-standard": "^5.0.4"
+    },
+    "extra": {
+        "class": "PHPStan\\ExtensionInstaller\\Plugin"
     },
     "autoload": {
         "psr-4": {
             "PHPStan\\ExtensionInstaller\\": "src/"
         }
-    },
-    "extra": {
-        "class": "PHPStan\\ExtensionInstaller\\Plugin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "phpstan/phpstan-strict-rules": "^0.11",
         "slevomat/coding-standard": "^5.0.4"
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "class": "PHPStan\\ExtensionInstaller\\Plugin"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.11",
         "slevomat/coding-standard": "^5.0.4",
-        "phing/phing": "^2.16"
+        "phing/phing": "^2.16",
+        "ergebnis/composer-normalize": "^2.0.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR

* [x] runs `ergebnis/composer-normalize` with the `--dry-run` option in the `check` target
* [x] runs `composer normalize`
* [x] keeps packages sorted in `composer.json`