### PR TITLE
Allow plugin to be called from script

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,12 @@ Add `phpstan` key in the extension `composer.json`'s `extra` section:
 ## Limitations
 
 The extension installer depends on Composer script events, therefore you cannot use `--no-scripts` flag.
+
+If you really need this, you can add this to your own `composer.json`:
+```json
+    "scripts": {
+        "install-phpstan-extensions": "PHPStan\\ExtensionInstaller\\Plugin::process"
+    }
+```
+
+Then you can install it manually with `composer run install-phpstan-extensions`.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -74,7 +74,7 @@ PHP;
 		];
 	}
 
-	public function process(Event $event): void
+	public static function process(Event $event): void
 	{
 		$io = $event->getIO();
 


### PR DESCRIPTION
By changing `Plugin::process` method to static we can call it from a Composer script. Same approach as here: https://github.com/composer/package-versions-deprecated/blob/master/src/PackageVersions/Installer.php#L146

This is ideal for situations where you want to are using `composer install --no-scripts` but do want to install the PHPStan extensions. In my case composer automatically clears the cache which takes a lot of time on our CI (big project). 

You can add a script to your own `composer.json`:
```json
    "scripts": {
        "install-phpstan-extensions": "PHPStan\\ExtensionInstaller\\Plugin::process"
    }
```

And then run `composer run install-phpstan-extensions` to install the extensions:
```
$ composer run install-phpstan-extensions
> PHPStan\ExtensionInstaller\Plugin::process
phpstan/extension-installer: Extensions installed
```

Without this change, it's also possible, but it generates a deprecation notice:
```
$ composer run install-phpstan-extensions
> PHPStan\ExtensionInstaller\Plugin::process
Deprecation Notice: Non-static method PHPStan\ExtensionInstaller\Plugin::process() should not be called statically in phar:///usr/local/Cellar/composer/2.0.9/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:324
phpstan/extension-installer: Extensions installed
```