### PR TITLE
Install exported extensions from every composer package type

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -97,10 +97,7 @@ PHP;
 		$data = [];
 		$fs = new Filesystem();
 		foreach ($composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
-			if (
-				$package->getType() !== 'phpstan-extension'
-				&& !isset($package->getExtra()['phpstan'])
-			) {
+			if (!isset($package->getExtra()['phpstan'])) {
 				if (
 					strpos($package->getName(), 'phpstan') !== false
 					&& !in_array($package->getName(), [


### PR DESCRIPTION
Phpstan extensions must be ex/importable from every composer package type.

This functionality is already mentioned in the README https://github.com/phpstan/extension-installer/blob/1.1.0/README.md?plain=1#L53

Example usecase: https://github.com/mvorisek/atk4-hintable-mirror package is of standard `library` type and it provides php libraries together with custom phpstan rules.