### PR TITLE
Fixed issue where getInstallPath can return a relative path in rare cases.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,7 @@ use function array_keys;
 use function dirname;
 use function file_exists;
 use function file_put_contents;
+use function getcwd;
 use function in_array;
 use function is_file;
 use function ksort;
@@ -21,6 +22,7 @@ use function md5_file;
 use function sprintf;
 use function strpos;
 use function var_export;
+use const DIRECTORY_SEPARATOR;
 
 final class Plugin implements PluginInterface, EventSubscriberInterface
 {
@@ -116,7 +118,13 @@ PHP;
 				}
 				continue;
 			}
-			$absoluteInstallPath = $installationManager->getInstallPath($package);
+
+			$installPath = $installationManager->getInstallPath($package);
+
+			$absoluteInstallPath = $fs->isAbsolutePath($installPath)
+				? $installPath
+				: getcwd() . DIRECTORY_SEPARATOR . $installPath;
+
 			$data[$package->getName()] = [
 				'install_path' => $absoluteInstallPath,
 				'relative_install_path' => $fs->findShortestPath(dirname($generatedConfigFilePath), $absoluteInstallPath, true),


### PR DESCRIPTION
In [some rare cases](https://github.com/composer/installers/commit/092ce6f9b753d7a4ca6a9fe373ac63c42b4a6aa8) `getInstallPath` can return a relative path instead of an absolute one, causing the extension installation to fail and halt composer with an exception:

![image](https://user-images.githubusercontent.com/28307684/196182364-4c0878d2-9e52-46e5-bdc8-c2b5be5c885e.png)

this has been fixed in the `composer/installers` package at `^2.2` but can still affect users of `composers/installers` `^1.0` for example, (which drupal currently ships with `^1.9`).

the `getcwd` fix has been lifted directly from how it was fixed in the `composer/installers`PR.