### PR TITLE
Fix ignoring phpstan/phpstan-phpunit in the root composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,7 @@
         }
     },
     "extra": {
-        "class": "PHPStan\\ExtensionInstaller\\Plugin",
-        "phpstan/extension-installer": {
-            "ignore": ["phpstan/phpstan-phpunit"]
-        }
+        "class": "PHPStan\\ExtensionInstaller\\Plugin"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
May have accidentally included this configuration in the root `composer.json` :sweat_smile: 

luckily the package isn't using that extension so it had no affect, but would be confusing in future if it was installed

sorry about that!