### PR TITLE
Add keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": [
         "MIT"
     ],
+    "keywords": ["dev", "static analysis"],
     "require": {
         "php": "^7.2 || ^8.0",
         "composer-plugin-api": "^2.0",


### PR DESCRIPTION
This way, Composer automatically suggests to install it under require-dev.